### PR TITLE
Add NativeArray<byte> overload for TagDetector

### DIFF
--- a/Packages/jp.keijiro.apriltag/README.md
+++ b/Packages/jp.keijiro.apriltag/README.md
@@ -87,6 +87,13 @@ texture.GetPixels32(buffer);
 detector.ProcessImage(buffer, fx, fy, cx, cy, tagSize);
 ```
 
+If you already have a grayscale `NativeArray<byte>` (e.g. from an ARFoundation
+`XRCpuImage`), pass it directly to avoid additional conversions:
+
+```csharp
+detector.ProcessImage(imageBytes, fx, fy, cx, cy, tagSize);
+```
+
 You can retrieve the detected tags from the `DetectedTags` property.
 
 ```csharp

--- a/Packages/jp.keijiro.apriltag/Runtime/Unity/Internal/ImageConverter.cs
+++ b/Packages/jp.keijiro.apriltag/Runtime/Unity/Internal/ImageConverter.cs
@@ -1,5 +1,7 @@
 using System;
 using Unity.Burst;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using Color32 = UnityEngine.Color32;
 using ImageU8 = AprilTag.Interop.ImageU8;
 
@@ -19,6 +21,14 @@ static class ImageConverter
                 BurstConvert(src, dst, image.Width, image.Height, image.Stride);
     }
 
+    public unsafe static void
+      Convert(NativeArray<byte> data, ImageU8 image)
+    {
+        var src = (byte*)NativeArrayUnsafeUtility.GetUnsafeReadOnlyPtr(data);
+        fixed (byte* dst = &image.Buffer.GetPinnableReference())
+            BurstCopy(src, dst, image.Width, image.Height, image.Stride);
+    }
+
     [BurstCompile]
     unsafe static void BurstConvert
       (Color32* src, byte* dst, int width, int height, int stride)
@@ -30,6 +40,22 @@ static class ImageConverter
         {
             for (var x = 0; x < width; x++)
                 dst[offs_dst + x] = src[offs_src + x].g;
+
+            offs_src += width;
+            offs_dst -= stride;
+        }
+    }
+
+    [BurstCompile]
+    unsafe static void BurstCopy
+      (byte* src, byte* dst, int width, int height, int stride)
+    {
+        var offs_src = 0;
+        var offs_dst = stride * (height - 1);
+
+        for (var y = 0; y < height; y++)
+        {
+            UnsafeUtility.MemCpy(dst + offs_dst, src + offs_src, (uint)width);
 
             offs_src += width;
             offs_dst -= stride;

--- a/Packages/jp.keijiro.apriltag/Runtime/Unity/TagDetector.cs
+++ b/Packages/jp.keijiro.apriltag/Runtime/Unity/TagDetector.cs
@@ -61,7 +61,24 @@ public sealed class TagDetector : System.IDisposable
     }
 
     public void ProcessImage
+      (NativeArray<byte> image, float fx, float fy, float cx, float cy, float tagSize)
+    {
+        ImageConverter.Convert(image, _image);
+        RunDetectorAndEstimator(fx, fy, cx, cy, tagSize);
+    }
+
+    public void ProcessImage
       (ReadOnlySpan<Color32> image, float fov, float tagSize)
+    {
+        ImageConverter.Convert(image, _image);
+        var fl = _image.Height * 0.5f / Mathf.Tan(fov * 0.5f);
+        var cx = _image.Width * 0.5f;
+        var cy = _image.Height * 0.5f;
+        RunDetectorAndEstimator(fl, fl, cx, cy, tagSize);
+    }
+
+    public void ProcessImage
+      (NativeArray<byte> image, float fov, float tagSize)
     {
         ImageConverter.Convert(image, _image);
         var fl = _image.Height * 0.5f / Mathf.Tan(fov * 0.5f);

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ texture.GetPixels32(buffer);
 detector.ProcessImage(buffer, fx, fy, cx, cy, tagSize);
 ```
 
+If you already have a grayscale `NativeArray<byte>` (for example obtained from
+an `XRCpuImage`), you can pass it directly without converting to `Color32`:
+
+```csharp
+detector.ProcessImage(imageBytes, fx, fy, cx, cy, tagSize);
+```
+
 You can retrieve the detected tags from the `DetectedTags` property.
 
 ```csharp


### PR DESCRIPTION
## Summary
- support feeding grayscale `NativeArray<byte>` images directly into the detector
- add burst optimized copy in `ImageConverter`
- document the new usage

## Testing
- `ls Tests` (no tests present)


------
https://chatgpt.com/codex/tasks/task_e_687533f50fe08328ae51f28326c2ca07