### PR TITLE
Expose decision metrics in TagPose

### DIFF
--- a/Packages/jp.keijiro.apriltag/Runtime/Interop/Pose.cs
+++ b/Packages/jp.keijiro.apriltag/Runtime/Interop/Pose.cs
@@ -10,6 +10,7 @@ public struct Pose : IDisposable
 
     IntPtr matd_r;
     IntPtr matd_t;
+    double err;
 
     #endregion
 
@@ -18,10 +19,12 @@ public struct Pose : IDisposable
     unsafe public ref Matd3x3 R => ref Util.AsRef<Matd3x3>((void*)matd_r);
     unsafe public ref Matd3x1 t => ref Util.AsRef<Matd3x1>((void*)matd_t);
 
+    public double ReprojectionError => err;
+
     public Pose(ref DetectionInfo info)
     {
         matd_r = matd_t = IntPtr.Zero;
-        _Estimate(ref info, ref this);
+        err = _Estimate(ref info, ref this);
     }
 
     public void Dispose()

--- a/Packages/jp.keijiro.apriltag/Runtime/Unity/Internal/PoseEstimationJob.cs
+++ b/Packages/jp.keijiro.apriltag/Runtime/Unity/Internal/PoseEstimationJob.cs
@@ -56,7 +56,14 @@ struct PoseEstimationJob : Unity.Jobs.IJobParallelFor
         var rot = math.quaternion(pose.R.AsFloat3x3());
         rot = rot.value * math.float4(-1, 1, -1, 1);
 
-        _output[i] = new TagPose(_input[i].Ref.ID, pos, rot);
+        _output[i] = new TagPose(
+            _input[i].Ref.ID,
+            pos,
+            rot,
+            _input[i].Ref.Hamming,
+            _input[i].Ref.DecisionMargin,
+            (float)pose.ReprojectionError
+        );
     }
 }
 

--- a/Packages/jp.keijiro.apriltag/Runtime/Unity/TagPose.cs
+++ b/Packages/jp.keijiro.apriltag/Runtime/Unity/TagPose.cs
@@ -10,12 +10,24 @@ public struct TagPose
     public int ID { get; }
     public Vector3 Position { get; }
     public Quaternion Rotation { get; }
+    public int Hamming { get; }
+    public float DecisionMargin { get; }
+    public float ReprojectionError { get; }
 
-    public TagPose(int id, Vector3 position, Quaternion rotation)
+    public TagPose(
+        int id,
+        Vector3 position,
+        Quaternion rotation,
+        int hamming,
+        float decisionMargin,
+        float reprojectionError)
     {
         ID = id;
         Position = position;
         Rotation = rotation;
+        Hamming = hamming;
+        DecisionMargin = decisionMargin;
+        ReprojectionError = reprojectionError;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ foreach (var tag in detector.DetectedTags)
     Debug.Log($"{tag.ID} {tag.Position} {tag.Rotation}");
 ```
 
+Each `TagPose` also exposes several quality indicators:
+
+* `Hamming`: The number of bit errors between the observed code and the nearest
+  valid tag (0 means an exact match).
+* `DecisionMargin`: A heuristic confidence measure from AprilTag; higher values
+  indicate more reliable detections.
+* `ReprojectionError`: The pose estimation error; lower values suggest a more
+  trustworthy pose.
+
 Dispose the detector object when you no longer need it.
 
 ```csharp


### PR DESCRIPTION
## Summary
- Add Hamming distance and pose reprojection error to TagPose for richer detection quality reporting
- Capture pose estimation error from native API and forward Hamming and error data through PoseEstimationJob
- Document Hamming, DecisionMargin, and ReprojectionError fields for filtering detections

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acacbbe8288328ab9e83713948085a